### PR TITLE
refactor(backend): adapt public product API response for store frontend

### DIFF
--- a/packages/backend/src/controllers/product.controller.js
+++ b/packages/backend/src/controllers/product.controller.js
@@ -32,20 +32,80 @@ const deleteAdminProduct = asyncHandler(async (req, res) => {
 // --- Contrôleurs pour le Store Front Public ---
 
 // Fonction de transformation pour le store
-const transformProductForStore = (product) => ({
-  id: product._id,
-  name: product.name,
-  image: product.images[0],
-  brand: product.brand,
-  review: product.averageRating,
-  price: product.price,
-  offerPrice: product.offerPrice,
+// const transformProductForStore = (product) => ({
+//   id: product._id,
+//   name: product.name,
+//   image: product.images[0],
+//   brand: product.brand,
+//   review: product.averageRating,
+//   price: product.price,
+//   offerPrice: product.offerPrice,
+// });
+
+// const getPublicProducts = asyncHandler(async (req, res) => {
+//   const productsFromDB = await productService.getAllProducts({ status: 'active' });
+//   const productsForStore = productsFromDB.map(transformProductForStore);
+//   return res.status(200).json(new ApiResponse(200, productsForStore));
+// });
+
+/**
+ * Fonction de transformation pour adapter les données du produit au format attendu par le frontend du "Store".
+ * C'est ici que la magie opère : on passe du modèle de la base de données au modèle de la vue.
+ * @param {Document} product - Le document produit complet provenant de Mongoose.
+ * @returns {object} Un objet formaté pour le store front.
+ */
+const transformProductForStore = (product) => {
+  // Fonction utilitaire pour formater les prix en chaînes de caractères avec un symbole monétaire.
+  const formatPrice = (priceValue) => {
+    if (typeof priceValue !== 'number') return null;
+    return `$${priceValue.toFixed(2)}`;
+  };
+
+  return {
+    // Mapping champ par champ
+    id: product._id,
+    title: product.name, // 'name' devient 'title'
+    image: product.images && product.images.length > 0 ? product.images[0] : 'default-product-image.jpg', // On prend la première image du tableau
+    brand: product.brand || null,
+    review: Math.round(product.averageRating) || 0, // On utilise le champ virtuel 'averageRating' et on l'arrondit
+    
+    // Formatage des prix en chaînes de caractères
+    price: formatPrice(product.price),
+    offer_price: formatPrice(product.offerPrice), // 'offerPrice' devient 'offer_price' et est formaté
+
+    // Mapping des booléens et autres champs
+    campaingn_product: product.isCampaignProduct, // 'isCampaignProduct' devient 'campaingn_product'
+
+    // Ces champs n'existent pas dans notre modèle de base de données.
+    // On renvoie 'null' comme dans l'exemple pour assurer la cohérence avec le frontend.
+    cam_product_available: null,
+    cam_product_sale: null,
+    product_type: product.category, // On peut mapper 'category' à 'product_type'
+  };
+};
+
+// On utilise maintenant notre nouveau transformateur.
+const getPublicProducts = asyncHandler(async (req, res) => {
+  // On récupère uniquement les produits actifs pour le store
+  const productsFromDB = await productService.getAllProducts({ status: 'active' });
+  
+  // On applique notre transformation détaillée sur chaque produit
+  const productsForStore = productsFromDB.map(transformProductForStore);
+  
+  return res.status(200).json(new ApiResponse(200, productsForStore));
 });
 
-const getPublicProducts = asyncHandler(async (req, res) => {
-  const productsFromDB = await productService.getAllProducts({ status: 'active' });
-  const productsForStore = productsFromDB.map(transformProductForStore);
-  return res.status(200).json(new ApiResponse(200, productsForStore));
+// Le contrôleur pour le détail d'un produit doit aussi utiliser la transformation
+const getPublicProductDetails = asyncHandler(async (req, res) => {
+    const productFromDB = await productService.getProductById(req.params.id);
+
+    // On s'assure que le produit est visible publiquement
+    if (productFromDB.status !== 'active') {
+        throw new ApiError(404, 'Product not found');
+    }
+
+    const productForStore = transformProductForStore(productFromDB);
+    return res.status(200).json(new ApiResponse(200, productForStore));
 });
 
 export const productController = {
@@ -55,4 +115,5 @@ export const productController = {
   updateAdminProduct,
   deleteAdminProduct,
   getPublicProducts,
+  getPublicProductDetails
 };

--- a/packages/backend/src/routes/public/product.routes.js
+++ b/packages/backend/src/routes/public/product.routes.js
@@ -3,10 +3,10 @@ import { productController } from '../../controllers/product.controller.js';
 
 const router = Router();
 
-// Routes publiques pour afficher les produits
+// Routes publiques pour afficher la liste des produits
 router.route('/').get(productController.getPublicProducts);
 
-// Route pour voir le détail d'un produit (on peut réutiliser le contrôleur admin)
-router.route('/:id').get(productController.getAdminProductDetails);
+// Route pour voir le détail d'un produit, qui utilise maintenant le contrôleur public dédié
+router.route('/:id').get(productController.getPublicProductDetails);
 
 export default router;


### PR DESCRIPTION
This commit modifies the product controller's public-facing endpoints.
The `transformProductForStore` function now maps the database model to the exact legacy data structure expected by the store frontend.

- Renames `name` to `title`.
- Flattens `images[0]` to `image`.
- Formats `price` and `offerPrice` as currency strings.
- Maps other fields like `isCampaignProduct` to `campaingn_product`.

This change ensures complete backward compatibility for the store client, avoiding any need for frontend refactoring.